### PR TITLE
[Vulns] Upgraded async

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "main": "index",
   "dependencies": {
-    "async": "0.2.10",
+    "async": "^3.2.2",
     "qs": "^6.0.0",
     "xml2js": "*"
   },


### PR DESCRIPTION
- Upgraded `async` library to 3.2.2 and confirmed that the `async.eachSeries` is still working as expected.
- Consulted https://github.com/caolan/async/blob/master/CHANGELOG.md to ensure *Breaking Changes* from 1.0, 2.0, and 3.0 don't affect code _in this repository_
  - `eachSeries` has been reimplemented internally to be a simplified call to `eachLimit` (with a limit of 1), but that does not change its behavior
